### PR TITLE
Fix warnings

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -298,8 +298,7 @@ impl epi::App for ImageEditor {
  
             
             if let Some(img) = self.image_operations.image_data.as_mut(){
-                ui.image(self.image_operations.texture_id,[self.image_operations.image_data.as_ref().unwrap().dimensions().0 as f32, 
-                self.image_operations.image_data.as_ref().unwrap().dimensions().1 as f32]);
+                ui.image(self.image_operations.texture_id,[img.dimensions().0 as f32, img.dimensions().1 as f32]);
                 
             }
  
@@ -324,7 +323,7 @@ impl epi::App for ImageEditor {
 
 fn load_image(path: &std::path::Path, frame: &epi::Frame) -> egui::TextureId{
 
-    let result = match image::io::Reader::open(path){
+    match image::io::Reader::open(path){
         Ok(result) => {
             let image= result.decode().unwrap();
             let dimensions = [image.dimensions().0 as usize, image.dimensions().1 as usize];

--- a/src/image_operations.rs
+++ b/src/image_operations.rs
@@ -23,7 +23,7 @@ impl ImageOperations{
 
     pub fn load_image_from_path(&mut self, path: &std::path::Path, frame: &epi::Frame) {
 
-        let result = match image::io::Reader::open(path){
+        match image::io::Reader::open(path){
             Ok(img) => {
                 self.image_data = Some(img.decode().unwrap());
                 let dimensions = [self.image_data.as_ref().unwrap().dimensions().0 as usize, self.image_data.as_ref().unwrap().dimensions().1 as usize];


### PR DESCRIPTION
The egui template seems to cause build errors if there are warnings in release mode, so let's fix them.